### PR TITLE
Fix archive listing to show only post section

### DIFF
--- a/themes/hugo-lithium-theme/layouts/_default/list.html
+++ b/themes/hugo-lithium-theme/layouts/_default/list.html
@@ -10,7 +10,7 @@
   </article>
   {{ else }}
   <div class="archive">
-    {{ range (where .Data.Pages "Section" "!=" "").GroupByDate "2006" }}
+    {{ range (where .Site.RegularPages "Section" "post").GroupByDate "2006" }}
     <h2 class="archive-title">{{ .Key }}</h2>
     {{ range .Pages }}
     <article class="archive-item">


### PR DESCRIPTION
## Summary
Updated the archive listing template to correctly filter and display only posts from the `post` section, replacing a problematic filter that was excluding all pages.

## Changes
- Modified `themes/hugo-lithium-theme/layouts/_default/list.html` to change the page filtering logic:
  - **Before**: `where .Data.Pages "Section" "!=" ""` — excluded pages with empty sections (unintended behavior)
  - **After**: `where .Site.RegularPages "Section" "post"` — explicitly includes only pages in the `post` section
  - Also switched from `.Data.Pages` to `.Site.RegularPages` for more reliable page access

## Details
This fix ensures the archive view displays the intended content (blog posts from `content/post/`) without inadvertently filtering out valid pages. The change aligns with the site's content structure where posts are organized under the `post` section.

https://claude.ai/code/session_01RyDu87hWW9QoZrkUnJwN9H